### PR TITLE
Riktas atkarpų ilgio skaičiavime. Perteklinių bekelės atkarpų šalinimas

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "takas",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "Maršrutų planavimo ir publikavimo priemonė",
   "private": true,
   "scripts": {
@@ -13,14 +13,14 @@
   "author": "Atvirasis žemėlapis",
   "license": "MIT License",
   "devDependencies": {
-    "css-loader": "^5.2.4",
+    "css-loader": "^5.2.6",
     "style-loader": "^2.0.0",
-    "webpack": "^5.36.1",
-    "webpack-cli": "^4.6.0",
+    "webpack": "^5.38.1",
+    "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^3.11.2"
   },
   "dependencies": {
-    "@mapbox/mapbox-gl-draw": "^1.2.2",
+    "@mapbox/mapbox-gl-draw": "^1.3.0",
     "mapbox-gl": "^1.13.1"
   }
 }


### PR DESCRIPTION
Pataisyti riktai:
1. Atkarpų ilgio skaičiavimas pamesdavo bendrą ilgį.
2. Jei paskutinė atkarpa yra bekelė, tai ją panaikinus likdavo jos „šešėlis“ maršruto peržiūros režime.